### PR TITLE
debug error message when network interface not found

### DIFF
--- a/kraken/network_chaos/actions.py
+++ b/kraken/network_chaos/actions.py
@@ -107,10 +107,7 @@ def verify_interface(test_interface, nodelst, template):
             interface_lst = output[:-1].split(",")
             for interface in test_interface:
                 if interface not in interface_lst:
-                    logging.error(
-                        "Interface %s not found in node %s interface list %s" % (interface, nodelst[pod_index]),
-                        interface_lst,
-                    )
+                    logging.error("Interface %s not found in node %s interface list %s" % (interface, nodelst[pod_index], interface_lst))
                     sys.exit(1)
         return test_interface
     finally:


### PR DESCRIPTION
Debug error occured when giving a bad network interface list

Traceback (most recent call last):
  File "/root/kraken/run_kraken.py", line 318, in <module>
    main(options.cfg)
  File "/root/kraken/run_kraken.py", line 239, in main
    network_chaos.run(scenarios_list, config, wait_duration)
  File "/root/kraken/kraken/network_chaos/actions.py", line 39, in run
    test_interface = verify_interface(test_interface, nodelst, pod_template)
  File "/root/kraken/kraken/network_chaos/actions.py", line 111, in verify_interface
    "Interface %s not found in node %s interface list %s" % (interface, nodelst[pod_index]),
TypeError: not enough arguments for format string

Signed-off-by: STARTX <clarue@startx.fr>